### PR TITLE
Fixes project root path in git-http-backend.

### DIFF
--- a/gitmesh/server.py
+++ b/gitmesh/server.py
@@ -248,7 +248,7 @@ async def git_http_endpoint(request):
     # 'HTTP_'
     # })
     env.update({
-        'GIT_PROJECT_ROOT': repo.path,
+        'GIT_PROJECT_ROOT': '.',
         'GIT_HTTP_EXPORT_ALL': '1',
     })
 


### PR DESCRIPTION
Since the command already runs inside the repository folder, the current working directory is already the right location.  The code was passing a path relative to the `gitmesh serve` command's current working directory in `GIT_PROJECT_ROOT`, but that path is wrong since we start the child process inside another folder.
