### PR TITLE
Silences warning on event loop close.

### DIFF
--- a/gitmesh/__main__.py
+++ b/gitmesh/__main__.py
@@ -147,7 +147,11 @@ def serve(ctx, host, port):
 
 def main():
     """Setuptools "console_script" entry point."""
-    return cli(obj={})
+    loop = asyncio.get_event_loop()
+    try:
+        return cli(obj={})
+    finally:
+        loop.close()
 
 
 # Required for `python -m gitmesh`.


### PR DESCRIPTION
There is an annoying error in the `signal` module during the event loop shutdown sequence.  Apparently, we always need to explicitly close the event loop to avoid it. 
