### PR TITLE
Ports tests to pytest-asyncio==0.5.0.

### DIFF
--- a/gitmesh/server.py
+++ b/gitmesh/server.py
@@ -275,9 +275,10 @@ async def git_http_endpoint(request):
     return web.Response(status=status, headers=head, body=body)
 
 
-async def serve_until(cancel, *, storage, host, port, linger=1.0, log=None):
+async def serve_until(cancel, *, storage, host, port, linger=1.0, log=None,
+                      loop=None):
     log = log or structlog.get_logger()
-    loop = asyncio.get_event_loop()
+    loop = loop or asyncio.get_event_loop()
 
     # Prepare a web application.
     app = web.Application(loop=loop)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,12 +46,13 @@ def cli():
     __main__.configure_logging(log_format='kv', utc=False)
 
     # See: http://click.pocoo.org/5/testing/
-    def run(command, input=None):
-        print('RUN:', command)
+    def run(loop, command, input=None):
         runner = click.testing.CliRunner()
         result = runner.invoke(
             __main__.cli, command,
-            obj={},
+            obj={
+                'loop': loop,
+            },
             env={},
             input=input,
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
+import asyncio
 import os
 import pkg_resources
 import signal
@@ -21,7 +22,7 @@ class DynamicObject(object):
             raise AttributeError(field, fields)
 
 
-def test_pre_receive(cli):
+def test_pre_receive(event_loop, cli):
 
     pre_receive = mock.MagicMock()
 
@@ -50,7 +51,7 @@ def test_pre_receive(cli):
         iter_entry_points.side_effect = mock_iter_entry_points
         with mock.patch('importlib.import_module') as import_module:
             import_module.side_effect = mock_import_module
-            cli(['pre-receive'], input='\n'.join([
+            cli(event_loop, ['pre-receive'], input='\n'.join([
                 'a b c',
                 'd e f',
             ]))
@@ -64,7 +65,7 @@ def test_pre_receive(cli):
     )
 
 
-def test_update(cli):
+def test_update(event_loop, cli):
 
     update = mock.MagicMock()
 
@@ -93,7 +94,7 @@ def test_update(cli):
         iter_entry_points.side_effect = mock_iter_entry_points
         with mock.patch('importlib.import_module') as import_module:
             import_module.side_effect = mock_import_module
-            cli(['update', 'a', 'b', 'c'])
+            cli(event_loop, ['update', 'a', 'b', 'c'])
 
     # Then it should have been invoked based on command-line arguments.
     update.assert_called_once_with(
@@ -103,7 +104,7 @@ def test_update(cli):
     )
 
 
-def test_post_receive(cli):
+def test_post_receive(event_loop, cli):
 
     post_receive = mock.MagicMock()
 
@@ -132,7 +133,7 @@ def test_post_receive(cli):
         iter_entry_points.side_effect = mock_iter_entry_points
         with mock.patch('importlib.import_module') as import_module:
             import_module.side_effect = mock_import_module
-            cli(['post-receive'], input='\n'.join([
+            cli(event_loop, ['post-receive'], input='\n'.join([
                 'a b c',
                 'd e f',
             ]))
@@ -146,7 +147,7 @@ def test_post_receive(cli):
     )
 
 
-def test_post_update(cli):
+def test_post_update(event_loop, cli):
 
     post_update = mock.MagicMock()
 
@@ -175,7 +176,7 @@ def test_post_update(cli):
         iter_entry_points.side_effect = mock_iter_entry_points
         with mock.patch('importlib.import_module') as import_module:
             import_module.side_effect = mock_import_module
-            cli(['post-update', 'a', 'b', 'c', 'd', 'e', 'f'])
+            cli(event_loop, ['post-update', 'a', 'b', 'c', 'd', 'e', 'f'])
 
     # Then it should have been invoked based on command-line arguments.
     post_update.assert_called_once_with(
@@ -195,4 +196,13 @@ def test_serve(event_loop, cli):
     # Make sure we eventually get a SIGINT/CTRL-C even.
     event_loop.call_later(1.0, os.kill, os.getpid(), signal.SIGINT)
 
-    cli(['serve'])
+    cli(event_loop, ['serve'])
+
+
+def test_serve_default_event_loop(event_loop, cli):
+
+    # Make sure we eventually get a SIGINT/CTRL-C even.
+    event_loop.call_later(1.0, os.kill, os.getpid(), signal.SIGINT)
+
+    asyncio.set_event_loop(event_loop)
+    cli(None, ['serve'])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -42,7 +42,7 @@ def test_await(event_loop):
         return hello(name)
 
     def hello_future(name):
-        f = asyncio.Future()
+        f = asyncio.Future(loop=event_loop)
         f.set_result(hello(name))
         return f
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,8 @@ deps =
   freezegun==0.3.7
   six==1.10.0
   structlog==16.0.0
-  pytest==2.9.1
-  pytest-asyncio==0.3.0
-  pytest-capturelog==0.7
+  pytest==3.0.2
+  pytest-asyncio==0.5.0
   testfixtures==4.9.1
   voluptuous==0.8.11
 passenv =


### PR DESCRIPTION
This switch brings some changes to event loop management to remove as much reliance on the default event loop as possible.

See [pytest-asyncio issue #35] for the rationale (`pytest-asyncio>=v0.4.0` brings some changes to the behavior of the `event_loop` fixture).
